### PR TITLE
Dependency updates and move to native dark mode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.doubleangels.nextdnsmanagement"
         minSdkVersion 28
         targetSdk 34
-        versionCode 231
-        versionName '5.2.0'
+        versionCode 232
+        versionName '5.2.1'
         resourceConfigurations += ["en", "zh", "nl", "fi", "fr", "de", "in", "it", "ja", "pl", "pt", "es", "sv", "tr"]
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 26 16:47:09 MST 2024
+#Tue Jun 25 09:48:07 MDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This update drops support for SDK 28 (Android 9) with the addition of Android 15 in the coming month or so. In addition, Android 12 and lower will no longer see the option to use the dark mode features in the app, this is due to the way that the native NextDNS dark mode is implemented and used within Android API's. If you are one of these affected users, please clear your app data after this update.